### PR TITLE
Adding support for WLS 12.1.3 Update 1 ZIP Distribution

### DIFF
--- a/OracleWebLogic/dockerfiles/12.1.3/.gitignore
+++ b/OracleWebLogic/dockerfiles/12.1.3/.gitignore
@@ -1,3 +1,4 @@
 fmw_12.1.3.0.0_wls.jar
 wls1213_dev.zip
+wls1213_devzip_update1.zip
 jdk-7u75-linux-x64.rpm

--- a/OracleWebLogic/dockerfiles/12.1.3/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.1.3/Dockerfile.developer
@@ -41,7 +41,8 @@ MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
 ENV JAVA_RPM jdk-7u75-linux-x64.rpm
-ENV WLS_PKG wls1213_dev.zip
+# ENV WLS_PKG wls1213_dev.zip
+ENV WLS_PKG wls1213_devzip_update1.zip
 ENV JAVA_HOME /usr/java/default
 ENV MW_HOME /u01/oracle/wls12130
 ENV CONFIG_JVM_ARGS -Djava.security.egd=file:/dev/./urandom

--- a/OracleWebLogic/dockerfiles/12.1.3/wls1213_devzip_update1.zip.download
+++ b/OracleWebLogic/dockerfiles/12.1.3/wls1213_devzip_update1.zip.download
@@ -4,12 +4,4 @@
 # 2. Download the Free Oracle WebLogic Server 12c (12.1.3) Zip Distribution and Installers for Developers
 # 3. Drop the downloaded file wls1213_dev.zip in the same folder as this file
 # 
-# 0a9152e312997a630ac122ba45581a18  wls1213_dev.zip
-
 99806123f7196f90c7f7884880577b3c  wls1213_devzip_update1.zip
-
-# Download this package from Oracle
-# ====
-#  - http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html 
-#
-53b8513548ae527d79899902524a06e1  jdk-7u75-linux-x64.rpm


### PR DESCRIPTION
Support to install WLS 12.1.3 Update 1, Checksum included, and .gitignore updated. 