### PR TITLE
Moved exit code check up to docker build command

### DIFF
--- a/OracleWebLogic/dockerfiles/buildDockerImage.sh
+++ b/OracleWebLogic/dockerfiles/buildDockerImage.sh
@@ -88,13 +88,11 @@ echo "Building image '$IMAGE_NAME' based on '$DISTRIBUTION' distribution..."
 
 # BUILD THE IMAGE (replace all environment variables)
 rm -f Dockerfile && ln -s Dockerfile.$DISTRIBUTION Dockerfile
-docker build --force-rm=true --no-cache=true --rm=true -t $IMAGE_NAME . 
-rm -f Dockerfile
-
-if [ $? -ne 0 ]; then
+docker build --force-rm=true --no-cache=true -t $IMAGE_NAME . || {
   echo "There was an error building the image."
-  exit $?
-fi
+  exit 1
+}
+rm -f Dockerfile
 
 echo ""
 


### PR DESCRIPTION
In OracleWebLogic/dockerfiles/buildDockerImage.sh the $? check was looking at the return code of "rm -f Dockerfile" not "docker build". I've moved the check up. 
A failed build should now halt script execution.