### PR TITLE
Update Dockerfile.developer

### DIFF
--- a/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
+++ b/OracleWebLogic/dockerfiles/12.2.1/Dockerfile.developer
@@ -44,8 +44,8 @@ ENV WLS_PKG fmw_12.2.1.0.0_wls_quick.jar
 ENV JAVA_HOME /usr/java/default
 ENV ORACLE_HOME /u01/oracle/weblogic
 ENV CONFIG_JVM_ARGS -Djava.security.egd=file:/dev/./urandom
-ENV USER_MEM_ARGS -Xms256m -Xmx512m -XX:MaxPermSize=2048m
-ENV JAVA_OPTIONS -XX:+PrintCommandLineFlags
+ENV USER_MEM_ARGS -Xms256m -Xmx512m
+ENV JAVA_OPTIONS -XX:+PrintCommandLineFlags -Djava.security.egd=file:/dev/./urandom
 
 # Setup filesystem and oracle user
 # ------------------------------------------------------------


### PR DESCRIPTION
(1) Removed  -XX:MaxPermSize=2048m from USER_MEM_ARGS as it is obsolete since Java 8
(2) Added  -Djava.security.egd=file:/dev/./urandom to JAVA_OPTIONS otherwise the sample 1221 domains will not start....